### PR TITLE
ci: drive package versions from the VERSION repo variable

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,15 +3,21 @@ name: Publish to NuGet
 on:
   push:
     branches: ["master"]
-    tags: ["v*.*.*"]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Published version comes from the `VERSION` repository variable
+    # (Settings -> Secrets and variables -> Actions -> Variables). All packed
+    # projects share it. After a successful publish the patch is incremented
+    # and written back. Edit the variable to set or jump the version.
+    env:
+      VERSION: ${{ vars.VERSION }}
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -42,9 +48,21 @@ jobs:
           for proj in "${projects[@]}"; do
             echo "📦 Packing $proj"
             dotnet restore "$proj"
-            dotnet build "$proj" --configuration Release --no-restore
-            dotnet pack "$proj" --configuration Release --no-build -o ./out
+            dotnet build "$proj" --configuration Release --no-restore -p:Version=$VERSION
+            dotnet pack "$proj" --configuration Release --no-build -o ./out -p:Version=$VERSION
           done
 
       - name: Publish to NuGet
-        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json"
+        run: dotnet nuget push ./out/*.nupkg --api-key ${{ secrets.GH_PAT }} --source "https://nuget.pkg.github.com/bladehero/index.json" --skip-duplicate
+
+      # Increment the patch and store it back in the VERSION variable so the
+      # next merge to master publishes the following version. Requires GH_PAT
+      # to have variable-write scope (classic `repo` or fine-grained Variables).
+      - name: Bump patch version for next run
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          next="$major.$minor.$((patch + 1))"
+          echo "Published $VERSION; setting VERSION variable to $next"
+          gh variable set VERSION --body "$next" --repo "$GITHUB_REPOSITORY"

--- a/src/Telegram.DotNet.Platform.Receiving.Background/Telegram.DotNet.Platform.Receiving.Background.csproj
+++ b/src/Telegram.DotNet.Platform.Receiving.Background/Telegram.DotNet.Platform.Receiving.Background.csproj
@@ -6,7 +6,6 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
 
-        <Version>9.0.9</Version>
         <Authors>bladehero</Authors>
         <PackageId>Telegram.DotNet.Platform.Receiving.Background</PackageId>
         <RepositoryUrl>https://github.com/bladehero/Telegram.DotNet.Platform</RepositoryUrl>

--- a/src/Telegram.DotNet.Platform.Receiving/Telegram.DotNet.Platform.Receiving.csproj
+++ b/src/Telegram.DotNet.Platform.Receiving/Telegram.DotNet.Platform.Receiving.csproj
@@ -6,7 +6,6 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
 
-        <Version>9.0.9</Version>
         <Authors>bladehero</Authors>
         <PackageId>Telegram.DotNet.Platform.Receiving</PackageId>
         <RepositoryUrl>https://github.com/bladehero/Telegram.DotNet.Platform</RepositoryUrl>

--- a/src/Telegram.DotNet.Platform/Telegram.DotNet.Platform.csproj
+++ b/src/Telegram.DotNet.Platform/Telegram.DotNet.Platform.csproj
@@ -6,7 +6,6 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
 
-        <Version>9.0.9</Version>
         <Authors>bladehero</Authors>
         <PackageId>Telegram.DotNet.Platform</PackageId>
         <RepositoryUrl>https://github.com/bladehero/Telegram.DotNet.Platform</RepositoryUrl>


### PR DESCRIPTION
## Summary
Replaces the hardcoded `<Version>9.0.9</Version>` in the three published projects with a single GitHub Actions **repository variable `VERSION`** (created, set to `9.0.9`). All three packages version in lockstep from it; each merge to `master` publishes the current value, then the workflow increments the patch and writes it back — gap-free, no commit-back.

**Packages covered:** `Telegram.DotNet.Platform`, `Telegram.DotNet.Platform.Receiving`, `Telegram.DotNet.Platform.Receiving.Background`.

- Job-level `env: VERSION: ${{ vars.VERSION }}`; the pack loop builds/packs each project with `-p:Version=$VERSION`.
- Publish uses `--skip-duplicate`; new **Bump** step (`gh variable set VERSION`).
- Dropped the `tags` trigger (master-only); checkout bumped to v4. The "Add GitHub Packages source" step (needed for restore) is unchanged.
- Removed `<Version>` from the three packed `.csproj` files.

## ⚠️ Requires GH_PAT with variable-write scope
The bump step needs `secrets.GH_PAT` with classic `repo` (or fine-grained *Variables: Read and write*) scope; `GITHUB_TOKEN` cannot manage variables. Without it the packages still publish but the version won't advance.

With `--skip-duplicate`, if `9.0.9` is already published the first run is a no-op publish and then bumps to `9.0.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)