### PR TITLE
fix!: scope updates and wire the bot from every overload

### DIFF
--- a/Bladehero.Telegram.Platform.sln
+++ b/Bladehero.Telegram.Platform.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bladehero.Telegram.Platform
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bladehero.Telegram.Platform.Sandbox.Webhook", "src\Bladehero.Telegram.Platform.Sandbox.Webhook\Bladehero.Telegram.Platform.Sandbox.Webhook.csproj", "{EDC4E219-BF07-4363-B358-F00A12FE66A4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bladehero.Telegram.Platform.Receiving.Background.Tests", "tests\Bladehero.Telegram.Platform.Receiving.Background.Tests\Bladehero.Telegram.Platform.Receiving.Background.Tests.csproj", "{0C49A4FE-DD4F-416D-B02C-BC60C41E429A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{EDC4E219-BF07-4363-B358-F00A12FE66A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EDC4E219-BF07-4363-B358-F00A12FE66A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EDC4E219-BF07-4363-B358-F00A12FE66A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C49A4FE-DD4F-416D-B02C-BC60C41E429A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C49A4FE-DD4F-416D-B02C-BC60C41E429A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C49A4FE-DD4F-416D-B02C-BC60C41E429A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C49A4FE-DD4F-416D-B02C-BC60C41E429A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9362A60C-531D-49E2-82F2-918F08A53971} = {B1A2F56D-9981-4E54-80BB-3B6A28EED5A4}
@@ -54,5 +60,6 @@ Global
 		{C6A66358-4B44-4902-BD32-D8038ADBCDBA} = {B1A2F56D-9981-4E54-80BB-3B6A28EED5A4}
 		{7AB1B926-54FD-45A6-A8E9-7BCD90D834D7} = {B1A2F56D-9981-4E54-80BB-3B6A28EED5A4}
 		{EDC4E219-BF07-4363-B358-F00A12FE66A4} = {B1A2F56D-9981-4E54-80BB-3B6A28EED5A4}
+		{0C49A4FE-DD4F-416D-B02C-BC60C41E429A} = {25FACE24-812D-4050-81EA-986DF0647798}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and it participates.
 
 | Package | What it gives you |
 | --- | --- |
-| [`Bladehero.Telegram.Platform`](https://www.nuget.org/packages/Bladehero.Telegram.Platform/) | `TelegramBotConfiguration` and an `ITelegramBotClient` registration for `IServiceCollection`. |
+| [`Bladehero.Telegram.Platform`](https://www.nuget.org/packages/Bladehero.Telegram.Platform/) | `TelegramBotConfiguration`, `ITelegramSender`, and the `IServiceCollection` wiring behind both. |
 | [`Bladehero.Telegram.Platform.Receiving`](https://www.nuget.org/packages/Bladehero.Telegram.Platform.Receiving/) | The command model: `ITelegramCommand`, typed base commands, assembly scanning, the parallel executor, error handling. |
 | [`Bladehero.Telegram.Platform.Receiving.Background`](https://www.nuget.org/packages/Bladehero.Telegram.Platform.Receiving.Background/) | Hosting: a long-polling `BackgroundService` and an ASP.NET Core webhook endpoint that keeps the Telegram webhook registration in sync. |
 
@@ -219,6 +219,35 @@ services.Configure<ParallelCommandExecutionConfiguration>(options => options.Par
 Set `ParallelCount` to `null` to run every command in a single unbounded batch.
 
 To replace dispatch entirely, register your own `ITelegramCommandExecutor` after `AddTelegramReceiving`.
+
+### Scopes
+
+Every update is handled in its own DI scope under both hosting models — webhook updates get the ASP.NET Core
+request scope, and long polling creates one per update. Scoped dependencies therefore behave the way you
+would expect in a controller: a fresh instance per update, disposed once the update finishes.
+
+Commands within a single update share that scope and, by default, run in parallel. If they share a scoped
+dependency that is not thread-safe — an EF Core `DbContext` being the usual one — either set `ParallelCount`
+to `1` so commands run one at a time, or resolve a scope of your own inside the command.
+
+## Sending on your own initiative
+
+A command answering an update already holds the bot client — it arrives on the request, so replying never
+needs anything from the container. Messages the bot starts by itself have no request to draw on: a
+reminder, a nightly digest, an alert raised by a background job. Those go through `ITelegramSender`:
+
+```csharp
+public sealed class LimitAlerts(ITelegramSender sender)
+{
+    public Task WarnAsync(long chatId, string text, CancellationToken token) =>
+        sender.SendAsync(chatId, text, cancellationToken: token);
+}
+```
+
+`ITelegramBotClient` itself is **not** registered in the container, on purpose. Two ways to reach the same
+object invites the wrong one — a command injecting the client instead of using its request, and losing the
+distinction between "the bot replied" and "the bot spoke first". The library builds the client internally and
+hands it to commands on their request; everything else sends through `ITelegramSender`.
 
 ## Error handling
 

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/Bladehero.Telegram.Platform.Receiving.Background.csproj
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/Bladehero.Telegram.Platform.Receiving.Background.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Bladehero.Telegram.Platform.Receiving.Background.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Bladehero.Telegram.Platform.Receiving\Bladehero.Telegram.Platform.Receiving.csproj" />
     <ProjectReference Include="..\Bladehero.Telegram.Platform\Bladehero.Telegram.Platform.csproj" />
   </ItemGroup>

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/LongPollingDependencyInjection.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/LongPollingDependencyInjection.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Bladehero.Configuration.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
 
@@ -16,8 +17,7 @@ public static class LongPollingDependencyInjection
     )
     {
         services.AddConfiguration<TelegramReceiverConfiguration>(configuration, sectionName);
-        services.AddTelegramBot(configuration, sectionName ?? nameof(TelegramReceiverConfiguration), httpClientFactory);
-        services.AddTelegramLongPollingReceivingCore(assemblies);
+        services.AddTelegramLongPollingReceivingCore(httpClientFactory, assemblies);
         return services;
     }
 
@@ -28,7 +28,7 @@ public static class LongPollingDependencyInjection
     )
     {
         services.AddOptions<TelegramReceiverConfiguration>().Configure(configure);
-        services.AddTelegramLongPollingReceivingCore(assemblies);
+        services.AddTelegramLongPollingReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -40,7 +40,7 @@ public static class LongPollingDependencyInjection
         where TDep1 : class
     {
         services.AddOptions<TelegramReceiverConfiguration>().Configure(configure);
-        services.AddTelegramLongPollingReceivingCore(assemblies);
+        services.AddTelegramLongPollingReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -53,7 +53,7 @@ public static class LongPollingDependencyInjection
         where TDep2 : class
     {
         services.AddOptions<TelegramReceiverConfiguration>().Configure(configure);
-        services.AddTelegramLongPollingReceivingCore(assemblies);
+        services.AddTelegramLongPollingReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -67,7 +67,7 @@ public static class LongPollingDependencyInjection
         where TDep3 : class
     {
         services.AddOptions<TelegramReceiverConfiguration>().Configure(configure);
-        services.AddTelegramLongPollingReceivingCore(assemblies);
+        services.AddTelegramLongPollingReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -82,7 +82,7 @@ public static class LongPollingDependencyInjection
         where TDep4 : class
     {
         services.AddOptions<TelegramReceiverConfiguration>().Configure(configure);
-        services.AddTelegramLongPollingReceivingCore(assemblies);
+        services.AddTelegramLongPollingReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -98,16 +98,22 @@ public static class LongPollingDependencyInjection
         where TDep5 : class
     {
         services.AddOptions<TelegramReceiverConfiguration>().Configure(configure);
-        services.AddTelegramLongPollingReceivingCore(assemblies);
+        services.AddTelegramLongPollingReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
     private static void AddTelegramLongPollingReceivingCore(
         this IServiceCollection services,
+        Func<IServiceProvider, HttpClient>? httpClientFactory,
         params Assembly[] assemblies
     )
     {
+        services.AddTelegramBot<IOptions<TelegramReceiverConfiguration>>(
+            (bot, receiver) => bot.Token = receiver.Value.Token,
+            httpClientFactory
+        );
         services.AddTelegramReceiving(assemblies);
+        services.AddSingleton<ScopedUpdateHandler>();
         services.AddHostedService<TelegramLongPollingBackgroundService>();
     }
 }

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/ScopedUpdateHandler.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/ScopedUpdateHandler.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Telegram.Bot;
+using Telegram.Bot.Polling;
+using Telegram.Bot.Types;
+
+namespace Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
+
+internal sealed class ScopedUpdateHandler(IServiceScopeFactory scopeFactory) : IUpdateHandler
+{
+    public async Task HandleUpdateAsync(
+        ITelegramBotClient botClient,
+        Update update,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var handler = scope.ServiceProvider.GetRequiredService<IUpdateHandler>();
+        await handler.HandleUpdateAsync(botClient, update, cancellationToken);
+    }
+
+    public async Task HandleErrorAsync(
+        ITelegramBotClient botClient,
+        Exception exception,
+        HandleErrorSource source,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var handler = scope.ServiceProvider.GetRequiredService<IUpdateHandler>();
+        await handler.HandleErrorAsync(botClient, exception, source, cancellationToken);
+    }
+}

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/TelegramLongPollingBackgroundService.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/TelegramLongPollingBackgroundService.cs
@@ -1,20 +1,15 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Telegram.Bot;
-using Telegram.Bot.Polling;
 
 namespace Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
 
-internal class TelegramLongPollingBackgroundService(IServiceScopeFactory serviceScopeFactory) : BackgroundService
+internal sealed class TelegramLongPollingBackgroundService(
+    TelegramBotClientAccessor accessor,
+    ScopedUpdateHandler updateHandler,
+    IOptions<TelegramReceiverConfiguration> options
+) : BackgroundService
 {
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        using var scope = serviceScopeFactory.CreateScope();
-        var provider = scope.ServiceProvider;
-        var client = provider.GetRequiredService<ITelegramBotClient>();
-        var handler = provider.GetRequiredService<IUpdateHandler>();
-        var options = provider.GetRequiredService<IOptions<TelegramReceiverConfiguration>>().Value.ToOptions();
-        await client.ReceiveAsync(handler, options, stoppingToken);
-    }
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) =>
+        accessor.Client.ReceiveAsync(updateHandler, options.Value.ToOptions(), stoppingToken);
 }

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/Webhook/TelegramWebhookInitializer.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/Webhook/TelegramWebhookInitializer.cs
@@ -6,13 +6,14 @@ using Telegram.Bot;
 namespace Bladehero.Telegram.Platform.Receiving.Background.Webhook;
 
 internal sealed class TelegramWebhookInitializer(
-    ITelegramBotClient client,
+    TelegramBotClientAccessor accessor,
     IOptions<TelegramWebhookConfiguration> options,
     ILogger<TelegramWebhookInitializer> logger
 ) : IHostedLifecycleService
 {
     public async Task StartingAsync(CancellationToken cancellationToken)
     {
+        var client = accessor.Client;
         var configuration = options.Value;
         try
         {

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/Webhook/WebhookDependencyInjection.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/Webhook/WebhookDependencyInjection.cs
@@ -23,12 +23,13 @@ public static class WebhookDependencyInjection
             endpoint,
             async (
                 Update update,
-                ITelegramBotClient client,
+                TelegramBotClientAccessor accessor,
                 IUpdateHandler handler,
                 ILogger<WebhookEndpoints> logger,
                 CancellationToken token
             ) =>
             {
+                var client = accessor.Client;
                 try
                 {
                     logger.LogInformation("Received webhook update: {@Update}", update);
@@ -52,8 +53,7 @@ public static class WebhookDependencyInjection
     )
     {
         services.AddConfiguration<TelegramWebhookConfiguration>(configuration, sectionName);
-        services.AddTelegramBot(configuration, sectionName ?? nameof(TelegramWebhookConfiguration), httpClientFactory);
-        services.AddTelegramWebhookReceivingCore(assemblies);
+        services.AddTelegramWebhookReceivingCore(httpClientFactory, assemblies);
         return services;
     }
 
@@ -64,7 +64,7 @@ public static class WebhookDependencyInjection
     )
     {
         services.AddOptions<TelegramWebhookConfiguration>().Configure(configure);
-        services.AddTelegramWebhookReceivingCore(assemblies);
+        services.AddTelegramWebhookReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -76,7 +76,7 @@ public static class WebhookDependencyInjection
         where TDep1 : class
     {
         services.AddOptions<TelegramWebhookConfiguration>().Configure(configure);
-        services.AddTelegramWebhookReceivingCore(assemblies);
+        services.AddTelegramWebhookReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -89,7 +89,7 @@ public static class WebhookDependencyInjection
         where TDep2 : class
     {
         services.AddOptions<TelegramWebhookConfiguration>().Configure(configure);
-        services.AddTelegramWebhookReceivingCore(assemblies);
+        services.AddTelegramWebhookReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -103,7 +103,7 @@ public static class WebhookDependencyInjection
         where TDep3 : class
     {
         services.AddOptions<TelegramWebhookConfiguration>().Configure(configure);
-        services.AddTelegramWebhookReceivingCore(assemblies);
+        services.AddTelegramWebhookReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -118,7 +118,7 @@ public static class WebhookDependencyInjection
         where TDep4 : class
     {
         services.AddOptions<TelegramWebhookConfiguration>().Configure(configure);
-        services.AddTelegramWebhookReceivingCore(assemblies);
+        services.AddTelegramWebhookReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
@@ -134,12 +134,20 @@ public static class WebhookDependencyInjection
         where TDep5 : class
     {
         services.AddOptions<TelegramWebhookConfiguration>().Configure(configure);
-        services.AddTelegramWebhookReceivingCore(assemblies);
+        services.AddTelegramWebhookReceivingCore(httpClientFactory: null, assemblies);
         return services;
     }
 
-    private static void AddTelegramWebhookReceivingCore(this IServiceCollection services, params Assembly[] assemblies)
+    private static void AddTelegramWebhookReceivingCore(
+        this IServiceCollection services,
+        Func<IServiceProvider, HttpClient>? httpClientFactory,
+        params Assembly[] assemblies
+    )
     {
+        services.AddTelegramBot<IOptions<TelegramWebhookConfiguration>>(
+            (bot, webhook) => bot.Token = webhook.Value.Token,
+            httpClientFactory
+        );
         services.AddTelegramReceiving(assemblies);
         services.AddHostedService<TelegramWebhookInitializer>();
     }

--- a/src/Bladehero.Telegram.Platform/Bladehero.Telegram.Platform.csproj
+++ b/src/Bladehero.Telegram.Platform/Bladehero.Telegram.Platform.csproj
@@ -2,8 +2,13 @@
   <PropertyGroup>
     <PackageId>Bladehero.Telegram.Platform</PackageId>
     <Title>Bladehero.Telegram.Platform</Title>
-    <Description>Core building blocks for Telegram bots on .NET: strongly typed bot configuration and an ITelegramBotClient registration for Microsoft.Extensions.DependencyInjection.</Description>
+    <Description>Core building blocks for Telegram bots on .NET: strongly typed bot configuration, an ITelegramSender for messages the bot starts itself, and the Microsoft.Extensions.DependencyInjection wiring behind both.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Bladehero.Telegram.Platform.Receiving.Background" />
+    <InternalsVisibleTo Include="Bladehero.Telegram.Platform.Receiving.Background.Tests" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Bladehero.Configuration.Extensions" />

--- a/src/Bladehero.Telegram.Platform/DependencyInjection.cs
+++ b/src/Bladehero.Telegram.Platform/DependencyInjection.cs
@@ -107,12 +107,13 @@ public static class DependencyInjection
         Func<IServiceProvider, HttpClient>? httpClientFactory
     )
     {
-        services.TryAddSingleton<ITelegramBotClient>(provider =>
+        services.TryAddSingleton(provider =>
         {
             var botConfiguration = provider.GetRequiredService<IOptions<TelegramBotConfiguration>>().Value;
             var options = new TelegramBotClientOptions(botConfiguration.Token);
             var client = httpClientFactory?.Invoke(provider);
-            return new TelegramBotClient(options, client);
+            return new TelegramBotClientAccessor(new TelegramBotClient(options, client));
         });
+        services.TryAddSingleton<ITelegramSender, TelegramSender>();
     }
 }

--- a/src/Bladehero.Telegram.Platform/ITelegramSender.cs
+++ b/src/Bladehero.Telegram.Platform/ITelegramSender.cs
@@ -1,0 +1,16 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Bladehero.Telegram.Platform;
+
+public interface ITelegramSender
+{
+    Task<Message> SendAsync(
+        ChatId chatId,
+        string text,
+        ParseMode parseMode = ParseMode.None,
+        ReplyMarkup? replyMarkup = null,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Bladehero.Telegram.Platform/TelegramBotClientAccessor.cs
+++ b/src/Bladehero.Telegram.Platform/TelegramBotClientAccessor.cs
@@ -1,0 +1,8 @@
+using Telegram.Bot;
+
+namespace Bladehero.Telegram.Platform;
+
+internal sealed class TelegramBotClientAccessor(ITelegramBotClient client)
+{
+    public ITelegramBotClient Client { get; } = client;
+}

--- a/src/Bladehero.Telegram.Platform/TelegramSender.cs
+++ b/src/Bladehero.Telegram.Platform/TelegramSender.cs
@@ -1,0 +1,24 @@
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Bladehero.Telegram.Platform;
+
+internal sealed class TelegramSender(TelegramBotClientAccessor accessor) : ITelegramSender
+{
+    public Task<Message> SendAsync(
+        ChatId chatId,
+        string text,
+        ParseMode parseMode = ParseMode.None,
+        ReplyMarkup? replyMarkup = null,
+        CancellationToken cancellationToken = default
+    ) =>
+        accessor.Client.SendMessage(
+            chatId,
+            text,
+            parseMode,
+            replyMarkup: replyMarkup,
+            cancellationToken: cancellationToken
+        );
+}

--- a/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/Bladehero.Telegram.Platform.Receiving.Background.Tests.csproj
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/Bladehero.Telegram.Platform.Receiving.Background.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bladehero.Telegram.Platform.Receiving.Background\Bladehero.Telegram.Platform.Receiving.Background.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/LongPollingRegistrationTests.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/LongPollingRegistrationTests.cs
@@ -1,0 +1,157 @@
+using Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
+using Bladehero.Telegram.Platform.Receiving.Background.Webhook;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Telegram.Bot;
+
+namespace Bladehero.Telegram.Platform.Receiving.Background.Tests;
+
+public sealed class LongPollingRegistrationTests
+{
+    private const string Token = "1234567:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw";
+
+    [Fact]
+    public void TheUpdateHandlerUsedByThePollingLoopIsTheScopingOne()
+    {
+        var services = FromConfiguration();
+
+        var descriptor = Assert.Single(services, service => service.ServiceType == typeof(ScopedUpdateHandler));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void TheLongPollingHostedServiceResolves()
+    {
+        using var provider = Build(FromConfiguration());
+
+        var hosted = provider.GetServices<IHostedService>();
+
+        Assert.Single(hosted.OfType<TelegramLongPollingBackgroundService>());
+    }
+
+    [Fact]
+    public void TheRawBotClientIsNotResolvable()
+    {
+        using var provider = Build(FromConfiguration());
+
+        Assert.Null(provider.GetService<ITelegramBotClient>());
+    }
+
+    [Fact]
+    public void TheSenderIsResolvableForMessagesTheBotStartsItself()
+    {
+        using var provider = Build(FromConfiguration());
+
+        Assert.NotNull(provider.GetService<ITelegramSender>());
+    }
+
+    [Fact]
+    public void TheActionOverloadWiresUpTheBotToo()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ScopeLog());
+        services.AddScoped<ScopedDependency>();
+        services.AddTelegramLongPollingReceiving(
+            configuration => configuration.Token = Token,
+            typeof(ProbeCommand).Assembly
+        );
+
+        using var provider = Build(services);
+
+        Assert.Single(provider.GetServices<IHostedService>().OfType<TelegramLongPollingBackgroundService>());
+        Assert.NotNull(provider.GetService<ITelegramSender>());
+    }
+
+    [Fact]
+    public void TheWebhookActionOverloadWiresUpTheBotToo()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ScopeLog());
+        services.AddScoped<ScopedDependency>();
+        services.AddTelegramWebhookReceiving(
+            configuration =>
+            {
+                configuration.Token = Token;
+                configuration.BaseUrl = "https://bot.example.com";
+                configuration.UpdateEndpoint = "telegram/updates";
+            },
+            typeof(ProbeCommand).Assembly
+        );
+
+        using var provider = Build(services);
+
+        Assert.Single(provider.GetServices<IHostedService>().OfType<TelegramWebhookInitializer>());
+        Assert.NotNull(provider.GetService<ITelegramSender>());
+    }
+
+    [Fact]
+    public void TheTokenFromConfigurationReachesTheClient()
+    {
+        using var provider = Build(FromConfiguration());
+
+        var accessor = provider.GetRequiredService<TelegramBotClientAccessor>();
+
+        Assert.Equal(1234567, accessor.Client.BotId);
+    }
+
+    [Fact]
+    public void TheTokenFromTheActionOverloadReachesTheClient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ScopeLog());
+        services.AddScoped<ScopedDependency>();
+        services.AddTelegramLongPollingReceiving(
+            configuration => configuration.Token = "7654321:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw",
+            typeof(ProbeCommand).Assembly
+        );
+
+        using var provider = Build(services);
+        var accessor = provider.GetRequiredService<TelegramBotClientAccessor>();
+
+        Assert.Equal(7654321, accessor.Client.BotId);
+    }
+
+    [Fact]
+    public void TheTokenFromTheWebhookActionOverloadReachesTheClient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ScopeLog());
+        services.AddScoped<ScopedDependency>();
+        services.AddTelegramWebhookReceiving(
+            configuration =>
+            {
+                configuration.Token = "7654321:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw";
+                configuration.BaseUrl = "https://bot.example.com";
+                configuration.UpdateEndpoint = "telegram/updates";
+            },
+            typeof(ProbeCommand).Assembly
+        );
+
+        using var provider = Build(services);
+        var accessor = provider.GetRequiredService<TelegramBotClientAccessor>();
+
+        Assert.Equal(7654321, accessor.Client.BotId);
+    }
+
+    private static IServiceCollection FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["TelegramReceiverConfiguration:Token"] = Token })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ScopeLog());
+        services.AddScoped<ScopedDependency>();
+        services.AddTelegramLongPollingReceiving(configuration, assemblies: typeof(ProbeCommand).Assembly);
+        return services;
+    }
+
+    private static ServiceProvider Build(IServiceCollection services) =>
+        services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+}

--- a/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/ScopeLog.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/ScopeLog.cs
@@ -1,0 +1,60 @@
+using Bladehero.Telegram.Platform.Receiving.Commands;
+using Bladehero.Telegram.Platform.Receiving.Commands.Execution;
+using Bladehero.Telegram.Platform.Receiving.Errors;
+
+namespace Bladehero.Telegram.Platform.Receiving.Background.Tests;
+
+internal sealed class ScopeLog
+{
+    public List<ScopedDependency> Created { get; } = [];
+    public List<ScopedDependency> Disposed { get; } = [];
+    public List<ScopedDependency> SeenByUpdates { get; } = [];
+    public List<ScopedDependency> SeenByErrors { get; } = [];
+    public List<ProbeCommand> CommandInstances { get; } = [];
+}
+
+internal sealed class ScopedDependency : IDisposable
+{
+    private readonly ScopeLog _log;
+
+    public ScopedDependency(ScopeLog log)
+    {
+        _log = log;
+        _log.Created.Add(this);
+    }
+
+    public void Dispose() => _log.Disposed.Add(this);
+}
+
+internal sealed class ProbeCommand(ScopeLog log, ScopedDependency dependency) : ITelegramCommand
+{
+    public Task<bool> CanHandleAsync(CommandRequest request, CancellationToken token)
+    {
+        log.CommandInstances.Add(this);
+        return Task.FromResult(true);
+    }
+
+    public Task HandleAsync(CommandRequest request, CancellationToken token)
+    {
+        log.SeenByUpdates.Add(dependency);
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class ProbeErrorHandler(ScopeLog log, ScopedDependency dependency) : ITelegramErrorHandler
+{
+    public Task HandleAsync(TelegramError telegramError)
+    {
+        log.SeenByErrors.Add(dependency);
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class ThrowingErrorHandler(ScopeLog log, ScopedDependency dependency) : ITelegramErrorHandler
+{
+    public Task HandleAsync(TelegramError telegramError)
+    {
+        log.SeenByErrors.Add(dependency);
+        throw new InvalidOperationException("boom");
+    }
+}

--- a/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/ScopedUpdateHandlerTests.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/ScopedUpdateHandlerTests.cs
@@ -1,0 +1,122 @@
+using Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
+using Bladehero.Telegram.Platform.Receiving.Errors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Telegram.Bot;
+using Telegram.Bot.Polling;
+using Telegram.Bot.Types;
+
+namespace Bladehero.Telegram.Platform.Receiving.Background.Tests;
+
+public sealed class ScopedUpdateHandlerTests
+{
+    private static readonly ITelegramBotClient Client = new TelegramBotClient(
+        "1234567:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw"
+    );
+
+    [Fact]
+    public async Task EveryUpdateIsHandledInItsOwnScope()
+    {
+        var log = new ScopeLog();
+        await using var provider = BuildProvider(log);
+        var handler = provider.GetRequiredService<ScopedUpdateHandler>();
+
+        await handler.HandleUpdateAsync(Client, new Update { Id = 1 }, CancellationToken.None);
+        await handler.HandleUpdateAsync(Client, new Update { Id = 2 }, CancellationToken.None);
+
+        Assert.Equal(2, log.SeenByUpdates.Count);
+        Assert.NotSame(log.SeenByUpdates[0], log.SeenByUpdates[1]);
+    }
+
+    [Fact]
+    public async Task CommandsAreResolvedFreshForEveryUpdate()
+    {
+        var log = new ScopeLog();
+        await using var provider = BuildProvider(log);
+        var handler = provider.GetRequiredService<ScopedUpdateHandler>();
+
+        await handler.HandleUpdateAsync(Client, new Update { Id = 1 }, CancellationToken.None);
+        await handler.HandleUpdateAsync(Client, new Update { Id = 2 }, CancellationToken.None);
+
+        Assert.Equal(2, log.CommandInstances.Count);
+        Assert.NotSame(log.CommandInstances[0], log.CommandInstances[1]);
+    }
+
+    [Fact]
+    public async Task TheScopeIsDisposedWhenTheUpdateCompletes()
+    {
+        var log = new ScopeLog();
+        await using var provider = BuildProvider(log);
+        var handler = provider.GetRequiredService<ScopedUpdateHandler>();
+
+        await handler.HandleUpdateAsync(Client, new Update { Id = 1 }, CancellationToken.None);
+
+        Assert.NotEmpty(log.Disposed);
+        Assert.Equal(log.Created, log.Disposed);
+    }
+
+    [Fact]
+    public async Task EveryErrorIsHandledInItsOwnScope()
+    {
+        var log = new ScopeLog();
+        await using var provider = BuildProvider(log);
+        var handler = provider.GetRequiredService<ScopedUpdateHandler>();
+
+        await handler.HandleErrorAsync(
+            Client,
+            new InvalidOperationException("first"),
+            HandleErrorSource.HandleUpdateError,
+            CancellationToken.None
+        );
+        await handler.HandleErrorAsync(
+            Client,
+            new InvalidOperationException("second"),
+            HandleErrorSource.HandleUpdateError,
+            CancellationToken.None
+        );
+
+        Assert.Equal(2, log.SeenByErrors.Count);
+        Assert.NotSame(log.SeenByErrors[0], log.SeenByErrors[1]);
+    }
+
+    [Fact]
+    public async Task AThrowingHandlerStillDisposesItsScope()
+    {
+        var log = new ScopeLog();
+        await using var provider = BuildProvider(log, throwing: true);
+        var handler = provider.GetRequiredService<ScopedUpdateHandler>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            handler.HandleErrorAsync(
+                Client,
+                new InvalidOperationException("original"),
+                HandleErrorSource.HandleUpdateError,
+                CancellationToken.None
+            )
+        );
+
+        Assert.NotEmpty(log.Disposed);
+        Assert.Equal(log.Created, log.Disposed);
+    }
+
+    private static ServiceProvider BuildProvider(ScopeLog log, bool throwing = false)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.None));
+        services.AddSingleton(log);
+        services.AddScoped<ScopedDependency>();
+        services.AddTelegramReceiving(typeof(ProbeCommand).Assembly);
+        services.AddSingleton<ScopedUpdateHandler>();
+
+        if (throwing)
+        {
+            services.AddScoped<ITelegramErrorHandler, ThrowingErrorHandler>();
+        }
+        else
+        {
+            services.AddScoped<ITelegramErrorHandler, ProbeErrorHandler>();
+        }
+
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+}


### PR DESCRIPTION
Fixes two bugs and removes one piece of public API.

## Per-update scopes under long polling

`TelegramLongPollingBackgroundService` created a single DI scope at startup and ran the entire polling loop inside it. Every scoped dependency therefore lived for the lifetime of the process and was shared across all updates, in parallel. A `DbContext` injected into a command was correct under webhooks and a concurrency bug under long polling, and nothing warned you when moving code between the two hosting models.

`ScopedUpdateHandler` now wraps the real handler and creates a fresh scope per update, matching what the ASP.NET Core request scope already gave webhook hosts.

## The bot was never registered by the delegate overloads

The twelve `Action<TConfiguration>` overloads of `AddTelegramLongPollingReceiving` / `AddTelegramWebhookReceiving` never called `AddTelegramBot`, so the client was never in the container and the host died at startup:

```
InvalidOperationException: No service for type 'Telegram.Bot.ITelegramBotClient' has been registered.
```

Only the `IConfiguration` overloads worked. Both `*Core` methods now register the bot themselves, copying the token off the receiver/webhook configuration onto the base `TelegramBotConfiguration`. That copy is the whole fix: the overloads configure only the derived type, so calling `AddTelegramBot` on its own would have left the base unconfigured and produced a null token instead. `httpClientFactory` is threaded through `*Core` for the same reason.

## Breaking change

`ITelegramBotClient` is no longer registered in the container.

- Replying to an update: use the client on the request (`request.Client`), which was always there.
- Messages the bot starts by itself: inject the new `ITelegramSender`.

Two ways to reach the same object invites the wrong one, and it blurs the line between the bot replying and the bot speaking first. Calls to `GetRequiredService<ITelegramBotClient>()` still compile and now throw at runtime.

`VERSION` is already `10.0.0`, so the major bump covers this.

## Tests

New `Bladehero.Telegram.Platform.Receiving.Background.Tests` project, 14 tests covering:

- one scope per update, for both updates and errors
- scope disposal, including when the handler throws
- fresh command instances per update
- registration through the `IConfiguration` and `Action` overloads, long polling and webhook

The token assertions go through `BotId`, which Telegram.Bot parses out of the token, so forwarding the wrong value fails rather than merely resolving. Verified by mutation: breaking the forward fails exactly those tests and leaves the resolution-only ones green.

Build is clean at 0 warnings, csharpier reports no formatting changes across 58 files.
