### PR TITLE
feat: add known-user commands and bot command helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,40 @@ public sealed class AuditCommand(ILogger<AuditCommand> logger) : ITelegramComman
 
 `CommandRequest` exposes `Update` and `Client` and deconstructs into both.
 
+### Bot commands
+
+`IsCommand` recognises a slash command in every form Telegram sends it — bare, `@`-qualified, and with
+arguments — so `CanHandleAsync` stays a one-liner:
+
+```csharp
+protected override bool Matches(Message message) => message.IsCommand("/last");
+```
+
+`ArgumentsOf("/last")` returns whatever followed the command, or `null` when there was nothing.
+
+### Commands for known users only
+
+Most bots serve people they already know about. `KnownUserCommand<TUser>` resolves the chat through your
+`ITelegramUserResolver<TUser>` and runs only when that succeeds, handing the resolved user to `HandleAsync`:
+
+```csharp
+internal sealed class LastExpensesCommand(ITelegramUserResolver<User> users, IExpenseQueries expenses)
+    : KnownUserCommand<User>(users)
+{
+    protected override bool Matches(Message message) => message.IsCommand("/last");
+
+    protected override async Task HandleAsync(TypedCommandRequest<Message> request, CancellationToken token)
+    {
+        var recent = await expenses.RecentAsync(User.Id, token);   // User is already resolved
+        await request.Client.SendMessage(request.Payload.Chat, Render(recent), cancellationToken: token);
+    }
+}
+```
+
+An unresolved chat makes the command decline the update rather than throw, so a stranger messaging the bot
+is ignored instead of raising an error for every message. The resolver is keyed on the chat id rather than
+the message, so the same implementation serves callback queries later.
+
 ## Execution model
 
 For each update the executor asks every command whether it can handle it, then runs all commands that said

--- a/src/Bladehero.Telegram.Platform.Receiving/Bladehero.Telegram.Platform.Receiving.csproj
+++ b/src/Bladehero.Telegram.Platform.Receiving/Bladehero.Telegram.Platform.Receiving.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Bladehero.Telegram.Platform.Receiving.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Bladehero.Configuration.Extensions" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Bladehero.Telegram.Platform.Receiving/Commands/Typed/Messages/ITelegramUserResolver.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving/Commands/Typed/Messages/ITelegramUserResolver.cs
@@ -1,0 +1,14 @@
+namespace Bladehero.Telegram.Platform.Receiving.Commands.Typed.Messages;
+
+/// <summary>
+/// Maps a Telegram chat onto whatever the application calls a user.
+/// </summary>
+/// <remarks>
+/// Keyed on the chat id rather than the message so the same resolver serves callback queries and any
+/// other update carrying a chat.
+/// </remarks>
+public interface ITelegramUserResolver<TUser>
+    where TUser : class
+{
+    Task<TUser?> ResolveAsync(long chatId, CancellationToken token);
+}

--- a/src/Bladehero.Telegram.Platform.Receiving/Commands/Typed/Messages/KnownUserCommand.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving/Commands/Typed/Messages/KnownUserCommand.cs
@@ -1,0 +1,39 @@
+using Telegram.Bot.Types;
+
+namespace Bladehero.Telegram.Platform.Receiving.Commands.Typed.Messages;
+
+/// <summary>
+/// A message command that only runs for chats the application recognises, exposing the resolved user
+/// to <see cref="TypedTelegramCommand{T}.HandleAsync(TypedCommandRequest{T}, CancellationToken)"/>.
+/// </summary>
+/// <remarks>
+/// An unresolved chat makes the command decline the update rather than throw, so a stranger messaging
+/// the bot is simply ignored instead of raising an error per message.
+/// </remarks>
+public abstract class KnownUserCommand<TUser>(ITelegramUserResolver<TUser> users) : MessageCommand
+    where TUser : class
+{
+    protected TUser User { get; private set; } = null!;
+
+    protected sealed override async Task<bool> CanHandleAsync(
+        TypedCommandRequest<Message> request,
+        CancellationToken token
+    )
+    {
+        if (!Matches(request.Payload))
+        {
+            return false;
+        }
+
+        var user = await users.ResolveAsync(request.Payload.Chat.Id, token);
+        if (user is null)
+        {
+            return false;
+        }
+
+        User = user;
+        return true;
+    }
+
+    protected abstract bool Matches(Message message);
+}

--- a/src/Bladehero.Telegram.Platform.Receiving/Commands/Typed/Messages/MessageExtensions.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving/Commands/Typed/Messages/MessageExtensions.cs
@@ -1,0 +1,28 @@
+using Telegram.Bot.Types;
+
+namespace Bladehero.Telegram.Platform.Receiving.Commands.Typed.Messages;
+
+public static class MessageExtensions
+{
+    /// <summary>
+    /// Whether the message is the given bot command — <c>/last</c>, <c>/last@BotName</c> or <c>/last 10</c>.
+    /// </summary>
+    public static bool IsCommand(this Message message, string command) =>
+        message.Text?.Split(' ', '@')[0].Equals(command, StringComparison.OrdinalIgnoreCase) is true;
+
+    /// <summary>
+    /// The text following a bot command, or <c>null</c> when the message carries none.
+    /// </summary>
+    public static string? ArgumentsOf(this Message message, string command)
+    {
+        if (!message.IsCommand(command))
+        {
+            return null;
+        }
+
+        var separator = message.Text!.IndexOf(' ');
+        return separator < 0 ? null
+            : message.Text[(separator + 1)..].Trim() is { Length: > 0 } text ? text
+            : null;
+    }
+}

--- a/tests/Bladehero.Telegram.Platform.Receiving.Tests/KnownUserCommandTests.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Tests/KnownUserCommandTests.cs
@@ -1,0 +1,91 @@
+using Bladehero.Telegram.Platform.Receiving.Commands.Execution;
+using Bladehero.Telegram.Platform.Receiving.Commands.Typed;
+using Bladehero.Telegram.Platform.Receiving.Commands.Typed.Messages;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+
+namespace Bladehero.Telegram.Platform.Receiving.Tests;
+
+public sealed class KnownUserCommandTests
+{
+    private const long KnownChat = 42;
+
+    private static readonly ITelegramBotClient Client = new TelegramBotClient(
+        "1234567:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw"
+    );
+
+    [Fact]
+    public async Task AKnownChatRunsTheCommandAndSeesItsUser()
+    {
+        var command = new ProbeCommand(new Resolver());
+        var request = RequestFrom(KnownChat, "/probe");
+
+        var canHandle = await command.CanHandleAsync(request, CancellationToken.None);
+        await command.HandleAsync(request, CancellationToken.None);
+
+        Assert.True(canHandle);
+        Assert.Equal("Nick", command.ResolvedUser?.Name);
+    }
+
+    [Fact]
+    public async Task AnUnknownChatIsDeclinedRatherThanThrowing()
+    {
+        var command = new ProbeCommand(new Resolver());
+
+        var canHandle = await command.CanHandleAsync(RequestFrom(999, "/probe"), CancellationToken.None);
+
+        Assert.False(canHandle);
+    }
+
+    [Fact]
+    public async Task AMessageThatDoesNotMatchIsDeclinedWithoutResolvingAUser()
+    {
+        var resolver = new Resolver();
+        var command = new ProbeCommand(resolver);
+
+        var canHandle = await command.CanHandleAsync(RequestFrom(KnownChat, "hello"), CancellationToken.None);
+
+        Assert.False(canHandle);
+        Assert.Equal(0, resolver.Calls);
+    }
+
+    private static CommandRequest RequestFrom(long chatId, string text) =>
+        new(
+            new Update
+            {
+                Id = 1,
+                Message = new Message
+                {
+                    Text = text,
+                    Chat = new Chat { Id = chatId },
+                },
+            },
+            Client
+        );
+
+    private sealed record TestUser(string Name);
+
+    private sealed class Resolver : ITelegramUserResolver<TestUser>
+    {
+        public int Calls { get; private set; }
+
+        public Task<TestUser?> ResolveAsync(long chatId, CancellationToken token)
+        {
+            Calls++;
+            return Task.FromResult(chatId == KnownChat ? new TestUser("Nick") : null);
+        }
+    }
+
+    private sealed class ProbeCommand(ITelegramUserResolver<TestUser> users) : KnownUserCommand<TestUser>(users)
+    {
+        public TestUser? ResolvedUser { get; private set; }
+
+        protected override bool Matches(Message message) => message.IsCommand("/probe");
+
+        protected override Task HandleAsync(TypedCommandRequest<Message> request, CancellationToken token)
+        {
+            ResolvedUser = User;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Bladehero.Telegram.Platform.Receiving.Tests/MessageExtensionsTests.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Tests/MessageExtensionsTests.cs
@@ -1,0 +1,48 @@
+using Bladehero.Telegram.Platform.Receiving.Commands.Typed.Messages;
+using Telegram.Bot.Types;
+
+namespace Bladehero.Telegram.Platform.Receiving.Tests;
+
+public sealed class MessageExtensionsTests
+{
+    [Theory]
+    [InlineData("/last")]
+    [InlineData("/LAST")]
+    [InlineData("/last@FamilyBudgetBot")]
+    [InlineData("/last 10")]
+    [InlineData("/last@FamilyBudgetBot 10")]
+    public void TheCommandIsRecognisedInEveryFormTelegramSendsIt(string text)
+    {
+        Assert.True(new Message { Text = text }.IsCommand("/last"));
+    }
+
+    [Theory]
+    [InlineData("/lastly")]
+    [InlineData("/other")]
+    [InlineData("last")]
+    [InlineData("tell me the /last one")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void AnythingElseIsNotTheCommand(string? text)
+    {
+        Assert.False(new Message { Text = text }.IsCommand("/last"));
+    }
+
+    [Theory]
+    [InlineData("/last 10", "10")]
+    [InlineData("/last@FamilyBudgetBot 10", "10")]
+    [InlineData("/last   spaced  out ", "spaced  out")]
+    public void ArgumentsAreTheTextAfterTheCommand(string text, string expected)
+    {
+        Assert.Equal(expected, new Message { Text = text }.ArgumentsOf("/last"));
+    }
+
+    [Theory]
+    [InlineData("/last")]
+    [InlineData("/last ")]
+    [InlineData("/other 10")]
+    public void WithoutArgumentsThereAreNone(string text)
+    {
+        Assert.Null(new Message { Text = text }.ArgumentsOf("/last"));
+    }
+}


### PR DESCRIPTION
@
Two pieces every command-style bot ends up writing by hand, extracted while wiring FamilyBudget onto the library.

## `IsCommand` / `ArgumentsOf`

`IsCommand` recognises a slash command in each form Telegram delivers it — `/last`, `/last@BotName`, `/last 10` — so `CanHandleAsync` stays a one-liner:

```csharp
protected override bool Matches(Message message) => message.IsCommand("/last");
```

`ArgumentsOf("/last")` returns whatever followed the command, or `null` when there was nothing.

## `KnownUserCommand<TUser>`

Most bots serve people they already know about. `KnownUserCommand<TUser>` resolves the chat through an `ITelegramUserResolver<TUser>` and runs only when that succeeds, handing the resolved user to `HandleAsync`.

Two decisions worth calling out:

**An unresolved chat declines the update rather than throwing.** A throw from `CanHandleAsync` unwinds into the error handler on every stray message; staying quiet is also the better answer to a stranger.

**The resolver is keyed on the chat id, not the message**, so the same implementation serves callback queries when inline keyboards arrive.

## Why command matching is a helper, not a base class

`SlashCommand` was the obvious shape, but it and `KnownUserCommand` both hook `CanHandleAsync`, and under single inheritance one has to sit under the other. A `SlashCommand` base would force `KnownUserCommand : SlashCommand` — which says every known-user command is a slash command, false as soon as a bot handles free text or voice. As an extension method it composes with anything.

## Tests

`Bladehero.Telegram.Platform.Receiving.Tests` had a csproj and no test files at all. It now has 20, covering command matching in every form Telegram sends it and the three `KnownUserCommand` paths — known chat, unknown chat, and a non-matching message, the last asserting the resolver is never called so a stray message costs no lookup.

Additive only: new public types plus an `InternalsVisibleTo` so the tests can build a `CommandRequest`. No existing API changes.
@