### PR TITLE
fix: clear an active webhook before long polling starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ await host.RunAsync();
 }
 ```
 
+Telegram serves a bot through `getUpdates` **or** a webhook, never both — polling a bot that still has one
+registered fails with HTTP 409 on every attempt. On startup the host checks for a webhook and deletes one
+if it finds it, logging the URL it removed. Worth knowing if the bot you are polling locally is the same
+bot serving a deployed webhook: starting long polling will unregister it.
+
 ## Quick start — webhook
 
 Best for production. Telegram pushes updates to an endpoint you expose.

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/LongPollingDependencyInjection.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/LongPollingDependencyInjection.cs
@@ -114,6 +114,7 @@ public static class LongPollingDependencyInjection
         );
         services.AddTelegramReceiving(assemblies);
         services.AddSingleton<ScopedUpdateHandler>();
+        services.AddHostedService<TelegramLongPollingInitializer>();
         services.AddHostedService<TelegramLongPollingBackgroundService>();
     }
 }

--- a/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/TelegramLongPollingInitializer.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/TelegramLongPollingInitializer.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+
+namespace Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
+
+/// <summary>
+/// Clears an active webhook before the polling loop starts.
+/// </summary>
+/// <remarks>
+/// Telegram serves a bot through <c>getUpdates</c> or a webhook, never both — polling a bot that still
+/// has one registered fails with HTTP 409 on every attempt. Asking for long polling settles which of
+/// the two the bot is using, so a leftover registration is removed rather than left to break startup.
+/// </remarks>
+internal sealed class TelegramLongPollingInitializer(
+    TelegramBotClientAccessor accessor,
+    IOptions<TelegramReceiverConfiguration> options,
+    ILogger<TelegramLongPollingInitializer> logger
+) : IHostedLifecycleService
+{
+    public async Task StartingAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var webhook = await accessor.Client.GetWebhookInfo(cancellationToken);
+            if (string.IsNullOrEmpty(webhook.Url))
+            {
+                return;
+            }
+
+            logger.LogWarning(
+                "Deleting the webhook registered at {Url} so long polling can start. Anything still "
+                    + "delivering updates to that address will stop receiving them.",
+                webhook.Url
+            );
+
+            await accessor.Client.DeleteWebhook(options.Value.DropPendingUpdates, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex, "Failed to clear the webhook before starting long polling");
+        }
+    }
+
+    #region Ignored
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    #endregion
+}

--- a/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/FakeBotClient.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/FakeBotClient.cs
@@ -1,0 +1,77 @@
+using Telegram.Bot;
+using Telegram.Bot.Args;
+using Telegram.Bot.Exceptions;
+using Telegram.Bot.Requests;
+using Telegram.Bot.Requests.Abstractions;
+using Telegram.Bot.Types;
+
+namespace Bladehero.Telegram.Platform.Receiving.Background.Tests;
+
+/// <summary>
+/// Answers the two requests the long-polling initializer makes and records what it was asked.
+/// </summary>
+internal sealed class FakeBotClient(string? webhookUrl = null, bool unreachable = false) : ITelegramBotClient
+{
+    public List<string> Requests { get; } = [];
+
+    public bool? DroppedPendingUpdates { get; private set; }
+
+    public Task<TResponse> SendRequest<TResponse>(
+        IRequest<TResponse> request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (unreachable)
+        {
+            throw new HttpRequestException("Telegram is unreachable");
+        }
+
+        Requests.Add(request.MethodName);
+
+        if (request is DeleteWebhookRequest delete)
+        {
+            DroppedPendingUpdates = delete.DropPendingUpdates;
+        }
+
+        object response = request switch
+        {
+            GetWebhookInfoRequest => new WebhookInfo { Url = webhookUrl ?? string.Empty },
+            DeleteWebhookRequest => true,
+            _ => throw new InvalidOperationException($"Unexpected request: {request.MethodName}"),
+        };
+
+        return Task.FromResult((TResponse)response);
+    }
+
+    #region Unused
+
+    public long BotId => 1234567;
+
+    public bool LocalBotServer => false;
+
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+    public IExceptionParser ExceptionsParser { get; set; } = new DefaultExceptionParser();
+
+    public event AsyncEventHandler<ApiRequestEventArgs>? OnMakingApiRequest
+    {
+        add { }
+        remove { }
+    }
+
+    public event AsyncEventHandler<ApiResponseEventArgs>? OnApiResponseReceived
+    {
+        add { }
+        remove { }
+    }
+
+    public Task DownloadFile(TGFile file, Stream destination, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public Task DownloadFile(string filePath, Stream destination, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public Task<bool> TestApi(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    #endregion
+}

--- a/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/LongPollingRegistrationTests.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/LongPollingRegistrationTests.cs
@@ -21,6 +21,16 @@ public sealed class LongPollingRegistrationTests
     }
 
     [Fact]
+    public void TheWebhookIsClearedBeforeThePollingLoopStarts()
+    {
+        using var provider = Build(FromConfiguration());
+
+        var hosted = provider.GetServices<IHostedService>();
+
+        Assert.Single(hosted.OfType<TelegramLongPollingInitializer>());
+    }
+
+    [Fact]
     public void TheLongPollingHostedServiceResolves()
     {
         using var provider = Build(FromConfiguration());

--- a/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/TelegramLongPollingInitializerTests.cs
+++ b/tests/Bladehero.Telegram.Platform.Receiving.Background.Tests/TelegramLongPollingInitializerTests.cs
@@ -1,0 +1,61 @@
+using Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+
+namespace Bladehero.Telegram.Platform.Receiving.Background.Tests;
+
+public sealed class TelegramLongPollingInitializerTests
+{
+    [Fact]
+    public async Task AnActiveWebhookIsDeletedSoPollingCanStart()
+    {
+        var client = new FakeBotClient("https://bot.example.com/telegram/updates");
+
+        await InitializerFor(client).StartingAsync(CancellationToken.None);
+
+        Assert.Equal(["getWebhookInfo", "deleteWebhook"], client.Requests);
+    }
+
+    [Fact]
+    public async Task WithNoWebhookRegisteredNothingIsDeleted()
+    {
+        var client = new FakeBotClient(webhookUrl: null);
+
+        await InitializerFor(client).StartingAsync(CancellationToken.None);
+
+        Assert.Equal(["getWebhookInfo"], client.Requests);
+    }
+
+    [Fact]
+    public async Task TheDeleteCarriesTheConfiguredPendingUpdateHandling()
+    {
+        var client = new FakeBotClient("https://bot.example.com/telegram/updates");
+
+        await InitializerFor(client, dropPendingUpdates: true).StartingAsync(CancellationToken.None);
+
+        Assert.True(client.DroppedPendingUpdates);
+    }
+
+    [Fact]
+    public async Task AFailureToReachTelegramDoesNotStopTheHostFromStarting()
+    {
+        var client = new FakeBotClient(unreachable: true);
+
+        var exception = await Record.ExceptionAsync(() => InitializerFor(client).StartingAsync(CancellationToken.None));
+
+        Assert.Null(exception);
+    }
+
+    private static TelegramLongPollingInitializer InitializerFor(
+        ITelegramBotClient client,
+        bool dropPendingUpdates = false
+    ) =>
+        new(
+            new TelegramBotClientAccessor(client),
+            Options.Create(
+                new TelegramReceiverConfiguration { Token = "unused", DropPendingUpdates = dropPendingUpdates }
+            ),
+            NullLogger<TelegramLongPollingInitializer>.Instance
+        );
+}


### PR DESCRIPTION
Telegram serves a bot through `getUpdates` **or** a webhook, never both. Polling a bot that still has one registered fails with HTTP 409 on every attempt, and the receive loop retries forever:

```
Telegram Bot API error 409: Conflict: can't use getUpdates method while webhook is active;
use deleteWebhook to delete the webhook first
```

Which is exactly what happened wiring FamilyBudget onto long polling, after `Bladehero.Telegram.Platform.Sandbox.Webhook` had run against the same bot and left a registration behind. The library gave no way out of that except reaching for curl.

## The fix

`AddTelegramWebhookReceiving` already registers `TelegramWebhookInitializer` to reconcile the webhook at startup. Long polling had no counterpart — it just started polling and hoped. `TelegramLongPollingInitializer` is that counterpart, on the same `IHostedLifecycleService.StartingAsync` hook so it runs before the polling service:

```csharp
var webhook = await accessor.Client.GetWebhookInfo(cancellationToken);
if (string.IsNullOrEmpty(webhook.Url))
{
    return;
}

logger.LogWarning("Deleting the webhook registered at {Url} so long polling can start. …", webhook.Url);
await accessor.Client.DeleteWebhook(options.Value.DropPendingUpdates, cancellationToken);
```

## Three decisions

**Check first, don't delete unconditionally.** Keeps startup silent in the normal case, and makes the destructive case visible in the log — which matters, because if that bot's webhook serves a deployment, running long polling locally takes it offline. The warning names the URL that was removed.

**No opt-out flag.** A bot cannot poll and receive webhooks at the same time, so asking for long polling already settles which of the two it is. A switch here would only let you configure the 409 back.

**Failures are logged and swallowed**, matching `TelegramWebhookInitializer`. If Telegram is unreachable at startup, the host still comes up and the polling loop reports the problem itself.

## Tests

Four behavioural tests against a `FakeBotClient` implementing `ITelegramBotClient` and answering the two requests the initializer makes: a registered webhook is deleted, no webhook means no delete call, `DropPendingUpdates` carries into the delete, and an unreachable Telegram doesn't stop the host. Plus one registration test — without it the initializer could be dead code and everything else would still pass.

I checked these actually catch the bug rather than merely agreeing with the new code: disabling the `DeleteWebhook` call fails exactly the two tests that assert it, and passes the rest.

19 tests in `Receiving.Background.Tests`, 39 across the solution. Build is warning-free.

## Downstream note

Anything asserting on "the single hosted service from this assembly" now sees two. `Bladehero.Telegram.Platform` 10.0.2 consumers with a test shaped that way — FamilyBudget has one — will need it narrowed to the specific type.
