### PR TITLE
chore: trim the long-polling initializer to house style

### DIFF
--- a/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/TelegramLongPollingInitializer.cs
+++ b/src/Bladehero.Telegram.Platform.Receiving.Background/LongPolling/TelegramLongPollingInitializer.cs
@@ -5,14 +5,8 @@ using Telegram.Bot;
 
 namespace Bladehero.Telegram.Platform.Receiving.Background.LongPolling;
 
-/// <summary>
-/// Clears an active webhook before the polling loop starts.
-/// </summary>
-/// <remarks>
-/// Telegram serves a bot through <c>getUpdates</c> or a webhook, never both — polling a bot that still
-/// has one registered fails with HTTP 409 on every attempt. Asking for long polling settles which of
-/// the two the bot is using, so a leftover registration is removed rather than left to break startup.
-/// </remarks>
+// Telegram serves a bot through getUpdates or a webhook, never both: polling one that still has a
+// webhook registered fails with 409 on every attempt.
 internal sealed class TelegramLongPollingInitializer(
     TelegramBotClientAccessor accessor,
     IOptions<TelegramReceiverConfiguration> options,
@@ -30,8 +24,7 @@ internal sealed class TelegramLongPollingInitializer(
             }
 
             logger.LogWarning(
-                "Deleting the webhook registered at {Url} so long polling can start. Anything still "
-                    + "delivering updates to that address will stop receiving them.",
+                "Deleting the webhook at {Url} so long polling can start - it will stop receiving updates.",
                 webhook.Url
             );
 


### PR DESCRIPTION
Deslopify pass over what #26 added — it shipped without one.

## Cut

**XML docs on an internal type.** The class had a `<summary>` restating its own method plus `<remarks>` carrying the rationale. `ScopedUpdateHandler` lost exactly that pair in review of #24, which settles the convention: internal types here carry no XML docs, while short `//` comments holding rationale are used throughout — `Directory.Packages.props`, `NuGet.config`, `LongPollingDependencyInjection`. What survives is the two lines that are genuinely non-obvious:

```csharp
// Telegram serves a bot through getUpdates or a webhook, never both: polling one that still has a
// webhook registered fails with 409 on every attempt.
```

**A log message saying it twice.** Two sentences across a concatenated string became one line with the same information.

Build warning-free, 39 tests green.

## Left alone, deliberately

`FakeBotClient` matches `DeleteWebhookRequest` twice — once to record the flag, once in the response switch. Merging them needs a side-effecting call inside a switch arm, which reads worse than the duplication.

The `#region` blocks stay: `TelegramWebhookInitializer` already uses one for the same interface boilerplate.

## Flagged, not cut

`MessageExtensions.ArgumentsOf` has no caller anywhere — not in this repo outside its own tests, not in FamilyBudget. I added it in #25 for `/last 10` later, which is speculative API by any reading. It is public and shipped in 10.0.2 and 10.0.3, so dropping it is a breaking change rather than a cleanup — your call whether it goes in a major bump or stays.